### PR TITLE
Add initial Sidekiq Enterprise Encryption support

### DIFF
--- a/lib/active_interaction/active_job/sidekiq/configured_job.rb
+++ b/lib/active_interaction/active_job/sidekiq/configured_job.rb
@@ -7,6 +7,10 @@ class ActiveInteraction::ActiveJob::Sidekiq::ConfiguredJob < ::ActiveJob::Config
     args = ActiveJob::Arguments.serialize(args)
     scope = @job_class.set(@options.except(:wait, :wait_until))
 
+    if @job_class.sidekiq_options['encrypt']
+      args.prepend(nil)
+    end
+
     if @options[:wait]
       scope.perform_in @options[:wait], *args
     elsif @options[:wait_until]

--- a/lib/active_interaction/active_job/sidekiq/job_helper.rb
+++ b/lib/active_interaction/active_job/sidekiq/job_helper.rb
@@ -1,5 +1,9 @@
 module ActiveInteraction::ActiveJob::Sidekiq::JobHelper
   def perform *args
+    if args.length > 1 && args[0].nil?
+      args.shift
+    end
+
     args = ActiveJob::Arguments.deserialize(args)
     self.class.parent.run!(*args)
   end


### PR DESCRIPTION
To make sidekiq encrypt parameters it need to use 2 argument perform method.

From [wiki](https://github.com/mperham/sidekiq/wiki/Ent-Encryption#configure-your-private-workers):

This has one special side effect: all encrypted workers must take >= 2 arguments. If you don't wish to have any cleartext, you can use `perform(nil, secret_bag)`.